### PR TITLE
🐛 bug(36): prevent blog post content from being cut off

### DIFF
--- a/api/src/service/notion-gateway/notion-gateway.ts
+++ b/api/src/service/notion-gateway/notion-gateway.ts
@@ -51,7 +51,6 @@ async function getAllIds(): Promise<BlogPost[]> {
 async function render(id: string) {
   const content = await notion.blocks.children.list({
     block_id: id,
-    page_size: 50,
   });
   const notionBlocks = parseNotion(content);
   return convert(notionBlocks);


### PR DESCRIPTION
The provided parameter in the list method cut the blog post off after 50 blocks. This was now changed - I'm not sure what the default value is or if it's still cutt off. But for now its sufficient, because the current blog post are shown entirely